### PR TITLE
Fixed Meetup ARUG link

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ layout: default
         </div>
         <div class="col-md-3">
           <h2>Links</h2>
-          <p><a class="btn btn-default btn-lg" href="http://www.meetup.com/arlingtonruby" role="button"><i class="fa fa-calendar"></i>  Meetup</a></p>
+          <p><a class="btn btn-default btn-lg" href="http://www.meetup.com/Arlington-Ruby" role="button"><i class="fa fa-calendar"></i>  Meetup</a></p>
           <p><a class="btn btn-default btn-lg" href="http://www.twitter.com/arlingtonruby" role="button"><i class="fa fa-twitter"></i>  Twitter</a></p>
           <p><a class="btn btn-default btn-lg" href="https://github.com/arlingtonruby" role="button"><i class="fa fa-github-alt"></i>  GitHub</a></p>
         </div>


### PR DESCRIPTION
The link to the Meetup group is using all lowercase characters without the '-' while the current accessible one uses 'Arlington-Ruby'.