### PR TITLE
add slack links

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ layout: default
   <div class="jumbotron">
     <div class="container">
       <div class="row">
-        <div class="col-md-6">
+        <div class="col-md-4">
           <h2>Arlington Ruby</h2>
           <p>We are a fortnightly meetup that sometimes talks about <a title="Link to Official Ruby Site" href="https://www.ruby-lang.org">Ruby</a>. Topics are usually Ruby-related, but not always. Most of our members write Ruby code, but not all of them.</p>
           <p>We also like to hang out at <a href="http://northsidesocialarlington.com/" title="Northside Social Website">Northside Social</a>.</p>
@@ -20,6 +20,13 @@ layout: default
           <p><a class="btn btn-default btn-lg" href="http://webchat.freenode.net?channels=arlingtonruby" role="button">Web Chat &raquo;</a></p>
         </div>
         <div class="col-md-3">
+          <h2>Slack</h2>
+          <p>We're often on Slack at dctech/#arlingtonruby</p>
+          <p><a class="btn btn-default btn-lg" href="https://dctech.slack.com" role="button">
+              DCTech Slack &raquo;</a></p>
+          <p><a class="btn btn-default btn-lg" href="http://dctechslack.herokuapp.com/" role="button">Slack Signup &raquo;</a></p>
+        </div>
+        <div class="col-md-2">
           <h2>Links</h2>
           <p><a class="btn btn-default btn-lg" href="http://www.meetup.com/Arlington-Ruby" role="button"><i class="fa fa-calendar"></i>  Meetup</a></p>
           <p><a class="btn btn-default btn-lg" href="http://www.twitter.com/arlingtonruby" role="button"><i class="fa fa-twitter"></i>  Twitter</a></p>

--- a/index.html
+++ b/index.html
@@ -6,22 +6,15 @@ layout: default
   <div class="jumbotron">
     <div class="container">
       <div class="row">
-        <div class="col-md-4">
+        <div class="col-md-6">
           <h2>Arlington Ruby</h2>
           <p>We are a fortnightly meetup that sometimes talks about <a title="Link to Official Ruby Site" href="https://www.ruby-lang.org">Ruby</a>. Topics are usually Ruby-related, but not always. Most of our members write Ruby code, but not all of them.</p>
           <p>We also like to hang out at <a href="http://northsidesocialarlington.com/" title="Northside Social Website">Northside Social</a>.</p>
           <p>You should come hang out.</p>
         </div>
         <div class="col-md-3">
-          <h2>Chat</h2>
-          <p>We're often on IRC at freenode/#arlingtonruby</p>
-          <p><a class="btn btn-default btn-lg" href="irc://irc.freenode.net:6667/#arlingtonruby" role="button">
-              IRC Client &raquo;</a></p>
-          <p><a class="btn btn-default btn-lg" href="http://webchat.freenode.net?channels=arlingtonruby" role="button">Web Chat &raquo;</a></p>
-        </div>
-        <div class="col-md-3">
           <h2>Slack</h2>
-          <p>We're often on Slack at dctech/#arlingtonruby</p>
+          <p>We're often on the DCTech Slack, channel #arlingtonruby</p>
           <p><a class="btn btn-default btn-lg" href="https://dctech.slack.com" role="button">
               DCTech Slack &raquo;</a></p>
           <p><a class="btn btn-default btn-lg" href="http://dctechslack.herokuapp.com/" role="button">Slack Signup &raquo;</a></p>


### PR DESCRIPTION
Adds slack signup links to the top of the page:
![image](https://cloud.githubusercontent.com/assets/273653/10382463/4bf0fea0-6df2-11e5-9a7b-d8f7a4ede531.png)

I can never get set up with IRC lol - do people still use that, or are most conversations happening on Slack now?

cc @csexton 