### PR TITLE
Remove Footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,0 @@
-<footer class="align-center">
-  You can find us on twitter
-  <a title="Link to Arlington Ruby on Twitter" href="http://www.twitter.com/arlingtonruby" target="_new">@arlingtonruby</a>, on IRC in #arlingtonruby via
-  <a title="Link to Freenode" href="http://freenode.net/" target="_new">freenode</a> and on the <a title="Link to Arlington Ruby on GitHub" href="https://github.com/arlingtonruby" target="_new">github</a>.
-</footer>

--- a/index.html
+++ b/index.html
@@ -41,5 +41,3 @@ layout: default
   {% include mentorship.html %}
 
 </section>
-
-{% include footer.html %}


### PR DESCRIPTION
The links at the top are more complete and thorough than the footer links.